### PR TITLE
Add Docker setup for panel service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+FROM rust:1.77 AS builder
+WORKDIR /app
+
+# Pre-fetch dependencies
+COPY Cargo.toml Cargo.lock ./
+COPY panel/Cargo.toml panel/Cargo.toml
+COPY mirror/Cargo.toml mirror/Cargo.toml
+RUN mkdir panel/src mirror/src \
+    && echo "fn main() {}" > panel/src/main.rs \
+    && echo "fn main() {}" > mirror/src/main.rs \
+    && cargo build --release -p panel \
+    && rm -r panel/src mirror/src
+
+# Build the application
+COPY . .
+RUN cargo build --release -p panel
+# Install SQLx CLI for running migrations
+RUN cargo install --locked sqlx-cli --features rustls,postgres
+
+FROM debian:bookworm-slim
+WORKDIR /app
+RUN apt-get update \
+    && apt-get install -y libssl3 ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/panel /usr/local/bin/panel
+COPY --from=builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
+COPY panel/migrations ./migrations
+
+ENV RUST_LOG=info
+EXPOSE 8000
+CMD ["sh", "-c", "sqlx migrate run && panel"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # leanpress
 A WordPress hosting service where users just drop in their backup, and your system auto-enchants (optimizes + deploys) it to a high-speed environment.
+
+## Running with Docker
+
+The repository includes a minimal Docker setup for local development. It starts a PostgreSQL database and the `panel` API service.
+
+```bash
+docker compose up --build
+```
+
+The API will be available at <http://localhost:8000> and connects to a PostgreSQL instance using the URL `postgres://panel:panel@postgres:5432/panel`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: panel
+      POSTGRES_PASSWORD: panel
+      POSTGRES_DB: panel
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U panel"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  panel:
+    build: .
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      POSTGRES_URL: postgres://panel:panel@postgres:5432/panel
+      RUST_LOG: info
+    ports:
+      - "8000:8000"
+
+volumes:
+  pgdata: {}


### PR DESCRIPTION
## Summary
- add Dockerfile to build and run the panel server
- add docker-compose to start panel alongside PostgreSQL
- document Docker usage in README

## Testing
- `cargo test`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb94b831c8832792fa96ab9e7706d0